### PR TITLE
使用daocloud构建了可以直接启动的镜像

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
-source 'https://rubygems.org'
+source 'https://gems.ruby-china.org'
+
 gem 'sinatra'
 gem 'thin'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,9 @@
 GEM
-  remote: https://rubygems.org/
+  remote: https://gems.ruby-china.org/
   specs:
-    concurrent-ruby (1.0.5)
     daemons (1.2.6)
     eventmachine (1.2.5)
     mustermann (1.0.2)
-    psych (3.0.2)
     rack (2.0.4)
     rack-protection (2.0.1)
       rack
@@ -24,8 +22,6 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  concurrent-ruby
-  psych
   sinatra
   thin
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,12 @@ POST https://sorry.xuty.tk/api/<template_name>/make
 
 ## 部署指南
 
-### 使用Docker
+### 使用Docker镜像快速启动
+```
+docker run -d -p 4567:4567 daocloud.io/sorry/gif:master
+```
+
+### 自行构建Docker Image启动
 ```
 docker build -t sorry .
 docker run --rm -it -p 4567:4567 sorry
@@ -82,7 +87,7 @@ gem sources --add https://gems.ruby-china.org/ --remove https://rubygems.org/
 
 # [可选] Linux服务器一般需要安装中文字体
 apt install language-pack-zh-hans
-apt install ttf-wqy-microhei 
+apt install ttf-wqy-microhei
 
 # 安装编译依赖
 apt install ruby-dev build-essential


### PR DESCRIPTION
* 为了方便用户直接启动服务，使用daocloud.io的免费服务构建了可以直接启动的镜像。daocloud的服务可以在代码变更的时候自动更新镜像。
* 更改了Gemfile的ruby源，Docker内配置的镜像对bundle install似乎未起效。


如果需要可以联系: miku@maimoe.com索要daocloud.io的账号